### PR TITLE
#15 Fix after navigating back, the user profile image url is not emitted

### DIFF
--- a/app/src/main/java/com/thiennguyen/survey/feature/home/HomeViewModel.kt
+++ b/app/src/main/java/com/thiennguyen/survey/feature/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.thiennguyen.survey.feature.home
 
+import androidx.lifecycle.MutableLiveData
 import com.thiennguyen.survey.base.BaseViewModel
 import com.thiennguyen.survey.data.Constants
 import com.thiennguyen.survey.domain.model.MetaModel
@@ -28,7 +29,7 @@ class HomeViewModel @Inject constructor(
 
     var loadMoreDataSet = LoadMoreDataSet()
     val onSurveyListChange = SingleLiveData<List<SurveyModel>>()
-    val onUserProfileAvatarChange = SingleLiveData<String>()
+    val onUserProfileAvatarChange = MutableLiveData<String>()
 
     init {
         getSurveyList()


### PR DESCRIPTION
Change `onUserProfileAvatarChange` variable type in `HomeViewModel` from `SingleLiveData` to `MutableLiveData`